### PR TITLE
[Story]: Update page pocket's logo routing for better user experience

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ const Footer = () => (
     <footer className="bg-white rounded-lg shadow dark:bg-gray-900 m-4">
       <div className="w-full max-w-screen-xl mx-auto p-4 md:py-8">
         <div className="sm:flex sm:items-center sm:justify-between">
-          <a href="https://v46-tier3-team-28-8mwx.vercel.app/" className="flex items-center gap-2 mb-4 sm:mb-0">
+          <a href="/" className="flex items-center gap-2 mb-4 sm:mb-0">
             <svg xmlns="http://www.w3.org/2000/svg" width="64" height="62" fill="none">
               <path
                 fillRule="evenodd"
@@ -40,7 +40,7 @@ const Footer = () => (
         <hr className="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8" />
         <span className="block text-sm text-gray-500 sm:text-center dark:text-gray-400">
           © 2023{' '}
-          <a href="https://v46-tier3-team-28-8mwx.vercel.app/" className="hover:underline">
+          <a href="/" className="hover:underline">
             Page Pocket™
           </a>
           . All Rights Reserved.

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -21,7 +21,7 @@ export default function Navigation({ session }: { session: Session }) {
           <button onClick={() => signIn()}>Sign in</button>
         )} */}
         <div className="flex items-center">
-          <Link className="font-semibold" href="/dashboard">
+          <Link className="font-semibold" href="/">
             <MainLogo />
           </Link>
           <Divider className="h-8 w-8 text-border sm:ml-4" />

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -21,7 +21,7 @@ export default function Navigation({ session }: { session: Session }) {
           <button onClick={() => signIn()}>Sign in</button>
         )} */}
         <div className="flex items-center">
-          <Link className="font-semibold" href="/">
+          <Link className="font-semibold" href="/dashboard">
             <MainLogo />
           </Link>
           <Divider className="h-8 w-8 text-border sm:ml-4" />


### PR DESCRIPTION
**Describe the problem**
Correct the routing of our Page Pocket logo.

**Actual behavior**
Currently, the Page Pocket logo is being routed to the homepage for user-friendliness. However, it seems there's a small typo in the routing URL for some i.e instead of [http](http://localhost:3000/dashboard), the logo is being routed to the Landing page.

**Suggested Fix**
Update the routing URL for the logo to http://localhost:3000/ to ensure it directs users to the intended Landing page. This should resolve the discrepancy in the routing.